### PR TITLE
feat: Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Git
+.git
+.gitignore
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.next
+pom.xml.releaseBackup
+
+# IDE
+.idea/
+*.iml
+*.iws
+
+# Logs
+logs/
+*.log
+
+# Docker
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1: Build the application
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+
+# Copy the Maven wrapper and the pom.xml
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
+
+# Download dependencies
+RUN ./mvnw dependency:go-offline
+
+# Copy the rest of the source code
+COPY src ./src
+
+# Build the application
+RUN ./mvnw clean install -DskipTests
+
+# Stage 2: Run the application
+FROM eclipse-temurin:21-jre-jammy
+WORKDIR /app
+
+# Copy the JAR file from the build stage
+COPY --from=build /app/target/raptor-service-1.0.0.jar .
+
+# Expose the port the application runs on
+EXPOSE 8080
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "raptor-service-1.0.0.jar"]


### PR DESCRIPTION
This commit introduces a `Dockerfile` to containerize the application. A multi-stage build is used to create a lean final image.

- The build stage uses a Maven image with JDK 21 to build the application JAR.
- The run stage uses a JRE 21 image to run the application.

A `.dockerignore` file is also added to exclude unnecessary files from the Docker build context, improving build times and reducing image size.