### PR TITLE
Update RaptorControllerTest to mock RaptorControllerValidator

### DIFF
--- a/src/test/java/it/raptor_service/controller/RaptorControllerTest.java
+++ b/src/test/java/it/raptor_service/controller/RaptorControllerTest.java
@@ -105,6 +105,8 @@ class RaptorControllerTest {
                 new byte[0]
         );
 
+        when(raptorControllerValidator.validateFile(any())).thenReturn("Error: File cannot be empty");
+
         mockMvc.perform(MockMvcRequestBuilders.multipart("/api/raptor/process-file")
                         .file(file))
                 .andExpect(status().isBadRequest())
@@ -122,6 +124,8 @@ class RaptorControllerTest {
                 largeContent
         );
 
+        when(raptorControllerValidator.validateFile(any())).thenReturn("Error: File too large. Maximum allowed: 10MB");
+
         mockMvc.perform(MockMvcRequestBuilders.multipart("/api/raptor/process-file")
                         .file(file))
                 .andExpect(status().isBadRequest())
@@ -136,6 +140,8 @@ class RaptorControllerTest {
                 "image/jpeg",
                 "image content".getBytes()
         );
+
+        when(raptorControllerValidator.validateFile(any())).thenReturn("Error: Only text files are supported");
 
         mockMvc.perform(MockMvcRequestBuilders.multipart("/api/raptor/process-file")
                         .file(file))
@@ -157,6 +163,8 @@ class RaptorControllerTest {
                 "text/plain",
                 longText.toString().getBytes()
         );
+
+        when(raptorControllerValidator.validateTextLength(any())).thenReturn("Error: File content too long. Maximum allowed: 1000000 characters");
 
         mockMvc.perform(MockMvcRequestBuilders.multipart("/api/raptor/process-file")
                         .file(file))


### PR DESCRIPTION
The controller tests for `processFile` were updated to mock the `RaptorControllerValidator`. This makes the tests more robust and less dependent on the implementation details of the validator.

The following tests were updated:
- `processFile_withEmptyFile_returnsBadRequest`
- `processFile_withLargeFile_returnsBadRequest`
- `processFile_withInvalidFileType_returnsBadRequest`
- `processFile_withLongContent_returnsBadRequest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded test coverage for file processing validation, covering: empty uploads, oversized files (10MB limit), unsupported formats (non-text), and excessive content length (1,000,000 characters).
  - Verifies user-facing error messages and corresponding 400 Bad Request responses for each scenario.
  - Improves confidence in consistent error handling without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->